### PR TITLE
Add dclint (Docker Compose Linter) support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,11 @@ aggregate statuses → exit code (0/1/2).
 1. Create `src/bosslint/linter/<name>.clj` with a `deflinter` form
 2. Require the new namespace in `src/bosslint/main.clj`'s ns form
 3. If it handles a new file type, add the regex→keyword to `path-type-pairs` and the keyword to `file-type-set` in `linter.clj`
-4. Update the supported linters table in `README.md` and `example/config.edn`
+4. Update `example/config.edn`
+
+## Communication
+
+- Issue and PR titles and descriptions must be written in English
 
 ## Code Style
 

--- a/example/config.edn
+++ b/example/config.edn
@@ -24,6 +24,9 @@
  {:disabled? false
   :command-options ["--no-hints"]}
 
+ :dclint
+ {:disabled? false}
+
  :eastwood
  {:disabled? false
   :version "1.4.3" ; default "RELEASE"

--- a/src/bosslint/linter.clj
+++ b/src/bosslint/linter.clj
@@ -30,6 +30,7 @@
    #"\.css$" :css
    #"\.dart$" :dart
    #"(^|/)Dockerfile(\.[-\w]+)?$" :docker
+   #"(^|/)(docker-)?compose(\.[-\w]+)?\.ya?ml$" :docker-compose
    #"(^|/)\.env$" :dot-env
    #"\.java$" :java
    #"\.json$" :json

--- a/src/bosslint/linter/dclint.clj
+++ b/src/bosslint/linter/dclint.clj
@@ -1,0 +1,26 @@
+(ns bosslint.linter.dclint
+  (:require [bosslint.linter :as linter :refer [deflinter]]
+            [bosslint.process :as process]
+            [io.aviso.ansi :as ansi]))
+
+(defn- dclint-command []
+  (cond
+    (process/command-exists? "dclint") ["dclint"]
+    (process/command-exists? "npx") ["npx" "dclint"]
+    :else nil))
+
+(deflinter :linter/dclint
+  (name [] "Docker Compose Linter")
+
+  (files [file-group]
+    (linter/select-files file-group [:docker-compose]))
+
+  (lint [{:keys [files]} conf]
+    (if-let [command (dclint-command)]
+      (let [args (concat command
+                         (:command-options conf)
+                         (map :absolute-path files))]
+        (if (zero? (apply process/run args))
+          :success
+          :error))
+      (println (ansi/yellow "Command not found: dclint or npx")))))

--- a/src/bosslint/main.clj
+++ b/src/bosslint/main.clj
@@ -10,6 +10,7 @@
                              cljstyle
                              commitlint
                              dartanalyzer
+                             dclint
                              dotenv-linter
                              eastwood
                              flake8


### PR DESCRIPTION
## Summary

- Add dclint linter for Docker Compose files (`compose.yml`, `docker-compose.yml`, etc.)
- Add `:docker-compose` file type to `path-type-pairs` in `linter.clj`
- Falls back to `npx dclint` when the `dclint` command is not directly available
- Update AGENTS.md: remove README.md from new linter checklist, add English-only rule for issue/PR communication

🤖 Generated with [Claude Code](https://claude.com/claude-code)