### PR TITLE
Update CI actions and Clojure CLI versions

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-13            # amd64 (x86_64)
-          - macos-14            # aarch64 (arm64)
+          - macos-15-intel      # amd64 (x86_64)
+          - macos-15            # aarch64 (arm64)
           - ubuntu-24.04        # amd64 (x86_64)
           - ubuntu-24.04-arm    # aarch64 (arm64)
     steps:

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -15,7 +15,7 @@ jobs:
           - ubuntu-24.04-arm    # aarch64 (arm64)
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -27,9 +27,9 @@ jobs:
           version: '22.3.0'
 
       - name: Setup Clojure
-        uses: DeLaGuardo/setup-clojure@13.2
+        uses: DeLaGuardo/setup-clojure@13.5
         with:
-          cli: '1.12.0.1530'
+          cli: '1.12.4.1602'
 
       - name: Test
         run: clojure -X:test
@@ -42,7 +42,7 @@ jobs:
         run: echo "version=$(./bosslint --version)" >> "$GITHUB_OUTPUT"
 
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: bosslint-${{ steps.get-version.outputs.version }}-${{ matrix.os }}
           path: target/bosslint*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup GraalVM
       uses: graalvm/setup-graalvm@v1
@@ -17,9 +17,9 @@ jobs:
         version: '22.3.0'
 
     - name: Setup Clojure
-      uses: DeLaGuardo/setup-clojure@13.2
+      uses: DeLaGuardo/setup-clojure@13.5
       with:
-        cli: '1.12.0.1530'
+        cli: '1.12.4.1602'
 
     - name: Test
       run: clojure -X:test


### PR DESCRIPTION
## Summary

- Update macOS runners for CI
- Update `actions/checkout` v4 → v6
- Update `actions/upload-artifact` v4 → v6
- Update `DeLaGuardo/setup-clojure` 13.2 → 13.5
- Update Clojure CLI 1.12.0.1530 → 1.12.4.1602