### PR TITLE
Scope ansible-lint to Ansible YAML by path with include/exclude

### DIFF
--- a/example/config.edn
+++ b/example/config.edn
@@ -3,7 +3,16 @@
 
  :ansible-lint
  {:disabled? false
-  :command-options ["-s"]}
+  :command-options ["-s"]
+
+  ;; Extra path regexes to include even if outside the conventional
+  ;; Ansible layout (playbooks/, roles/<r>/{tasks,handlers,meta,vars,defaults},
+  ;; group_vars/, host_vars/, inventories/, site.yml, playbook.yml,
+  ;; inventory.yml).
+  :include-paths ["^ansible/"]
+
+  ;; Path regexes to exclude from ansible-lint.
+  :exclude-paths ["/vendor/"]}
 
  :checkstyle
  {:disabled? false

--- a/src/bosslint/linter.clj
+++ b/src/bosslint/linter.clj
@@ -8,7 +8,7 @@
 
 (defmulti name identity)
 
-(defmulti files (fn [key file-group] key))
+(defmulti files (fn [key file-group conf] key))
 
 (defmulti lint (fn [key diff config] key))
 
@@ -42,6 +42,8 @@
    #"\.swift$" :swift
    #"\.tf$" :terraform
    #"^\.github/workflows/.+\.ya?ml$" :workflow
+   #"(^|/)(playbooks?|roles/[^/]+/(tasks|handlers|meta|vars|defaults)|(group|host)_vars|inventories)/.+\.ya?ml$" :ansible
+   #"(^|/)(site|playbook|inventory)\.ya?ml$" :ansible
    #"\.ya?ml$" :yaml})
 
 (def ^:private file-type-set

--- a/src/bosslint/linter/actionlint.clj
+++ b/src/bosslint/linter/actionlint.clj
@@ -5,7 +5,7 @@
 (deflinter :linter/actionlint
   (name [] "actionlint")
 
-  (files [file-group]
+  (files [file-group _]
     (linter/select-files file-group [:workflow]))
 
   (lint [{:keys [files]} _]

--- a/src/bosslint/linter/ansible_lint.clj
+++ b/src/bosslint/linter/ansible_lint.clj
@@ -2,11 +2,23 @@
   (:require [bosslint.linter :as linter :refer [deflinter]]
             [bosslint.process :as process]))
 
+(defn- match-any?
+  [patterns ^String s]
+  (boolean (some #(re-find (re-pattern %) s) patterns)))
+
 (deflinter :linter/ansible-lint
   (name [] "ansible-lint")
 
-  (files [file-group]
-    (linter/select-files file-group [:yaml]))
+  (files [file-group conf]
+    (let [ansible-paths (set (map :git-path (get file-group :ansible)))
+          includes (:include-paths conf)
+          excludes (:exclude-paths conf)]
+      (->> (linter/select-files file-group [:yaml])
+           (filter (fn [{:keys [git-path]}]
+                     (or (contains? ansible-paths git-path)
+                         (and (seq includes) (match-any? includes git-path)))))
+           (remove (fn [{:keys [git-path]}]
+                     (and (seq excludes) (match-any? excludes git-path)))))))
 
   (lint [{:keys [files]} conf]
     (when (linter/check-command "ansible-lint")

--- a/src/bosslint/linter/checkstyle.clj
+++ b/src/bosslint/linter/checkstyle.clj
@@ -5,7 +5,7 @@
 (deflinter :linter/checkstyle
   (name [] "Checkstyle")
 
-  (files [file-group]
+  (files [file-group _]
     (linter/select-files file-group [:java]))
 
   (lint [{:keys [files]} conf]

--- a/src/bosslint/linter/clj_kondo.clj
+++ b/src/bosslint/linter/clj_kondo.clj
@@ -5,7 +5,7 @@
 (deflinter :linter/clj-kondo
   (name [] "clj-kondo")
 
-  (files [file-group]
+  (files [file-group _]
     (linter/select-files file-group [:clj :cljc :cljs]))
 
   (lint [{:keys [files]} _]

--- a/src/bosslint/linter/cljfmt.clj
+++ b/src/bosslint/linter/cljfmt.clj
@@ -46,7 +46,7 @@
 (deflinter :linter/cljfmt
   (name [] "cljfmt")
 
-  (files [file-group]
+  (files [file-group _]
     (linter/select-files file-group [:clj :cljc :cljs]))
 
   (lint [{:keys [files]} conf]

--- a/src/bosslint/linter/cljstyle.clj
+++ b/src/bosslint/linter/cljstyle.clj
@@ -5,7 +5,7 @@
 (deflinter :linter/cljstyle
   (name [] "cljstyle")
 
-  (files [file-group]
+  (files [file-group _]
     (linter/select-files file-group [:clj :cljc :cljs]))
 
   (lint [{:keys [files]} _]

--- a/src/bosslint/linter/commitlint.clj
+++ b/src/bosslint/linter/commitlint.clj
@@ -5,7 +5,7 @@
 (deflinter :linter/commitlint
   (name [] "commitlint")
 
-  (files [file-group]
+  (files [file-group _]
     [:dummy])
 
   (lint [{:keys [ref1 ref2]} _]

--- a/src/bosslint/linter/dartanalyzer.clj
+++ b/src/bosslint/linter/dartanalyzer.clj
@@ -5,7 +5,7 @@
 (deflinter :linter/dartanalyzer
   (name [] "dartanalyzer")
 
-  (files [file-group]
+  (files [file-group _]
     (linter/select-files file-group [:dart]))
 
   (lint [{:keys [files]} conf]

--- a/src/bosslint/linter/dclint.clj
+++ b/src/bosslint/linter/dclint.clj
@@ -12,7 +12,7 @@
 (deflinter :linter/dclint
   (name [] "Docker Compose Linter")
 
-  (files [file-group]
+  (files [file-group _]
     (linter/select-files file-group [:docker-compose]))
 
   (lint [{:keys [files]} conf]

--- a/src/bosslint/linter/dotenv_linter.clj
+++ b/src/bosslint/linter/dotenv_linter.clj
@@ -5,7 +5,7 @@
 (deflinter :linter/dotenv-linter
   (name [] "dotenv-linter")
 
-  (files [file-group]
+  (files [file-group _]
     (linter/select-files file-group [:dot-env]))
 
   (lint [{:keys [files]} _]

--- a/src/bosslint/linter/eastwood.clj
+++ b/src/bosslint/linter/eastwood.clj
@@ -71,7 +71,7 @@
 (deflinter :linter/eastwood
   (name [] "Eastwood")
 
-  (files [file-group]
+  (files [file-group _]
     (->> (linter/select-files file-group [:clj :cljc])
          (remove (fn [{:keys [git-path]}]
                    (some #(re-find % git-path) excludes)))))

--- a/src/bosslint/linter/flake8.clj
+++ b/src/bosslint/linter/flake8.clj
@@ -5,7 +5,7 @@
 (deflinter :linter/flake8
   (name [] "Flake8")
 
-  (files [file-group]
+  (files [file-group _]
     (linter/select-files file-group [:python]))
 
   (lint [{:keys [files]} conf]

--- a/src/bosslint/linter/hadolint.clj
+++ b/src/bosslint/linter/hadolint.clj
@@ -5,7 +5,7 @@
 (deflinter :linter/hadolint
   (name [] "hadolint")
 
-  (files [file-group]
+  (files [file-group _]
     (linter/select-files file-group [:docker]))
 
   (lint [{:keys [files]} _]

--- a/src/bosslint/linter/jsonlint.clj
+++ b/src/bosslint/linter/jsonlint.clj
@@ -5,7 +5,7 @@
 (deflinter :linter/jsonlint
   (name [] "jsonlint")
 
-  (files [file-group]
+  (files [file-group _]
     (linter/select-files file-group [:json]))
 
   (lint [{:keys [files]} conf]

--- a/src/bosslint/linter/kubeval.clj
+++ b/src/bosslint/linter/kubeval.clj
@@ -70,7 +70,7 @@
 (deflinter :linter/kubeval
   (name [] "kubeval")
 
-  (files [file-group]
+  (files [file-group _]
     (->> (linter/select-files file-group [:yaml])
          (filter kube-yaml?)))
 

--- a/src/bosslint/linter/markdownlint.clj
+++ b/src/bosslint/linter/markdownlint.clj
@@ -5,7 +5,7 @@
 (deflinter :linter/markdownlint
   (name [] "markdownlint-cli")
 
-  (files [file-group]
+  (files [file-group _]
     (linter/select-files file-group [:markdown]))
 
   (lint [{:keys [files]} conf]

--- a/src/bosslint/linter/shellcheck.clj
+++ b/src/bosslint/linter/shellcheck.clj
@@ -5,7 +5,7 @@
 (deflinter :linter/shellcheck
   (name [] "ShellCheck")
 
-  (files [file-group]
+  (files [file-group _]
     (linter/select-files file-group [:shell]))
 
   (lint [{:keys [files]} _]

--- a/src/bosslint/linter/sql_lint.clj
+++ b/src/bosslint/linter/sql_lint.clj
@@ -5,7 +5,7 @@
 (deflinter :linter/sql-lint
   (name [] "sql-lint")
 
-  (files [file-group]
+  (files [file-group _]
     (linter/select-files file-group [:sql]))
 
   (lint [{:keys [files]} conf]

--- a/src/bosslint/linter/stylelint.clj
+++ b/src/bosslint/linter/stylelint.clj
@@ -5,7 +5,7 @@
 (deflinter :linter/stylelint
   (name [] "stylelint")
 
-  (files [file-group]
+  (files [file-group _]
     (linter/select-files file-group [:css :sass]))
 
   (lint [{:keys [files]} conf]

--- a/src/bosslint/linter/swiftlint.clj
+++ b/src/bosslint/linter/swiftlint.clj
@@ -5,7 +5,7 @@
 (deflinter :linter/swiftlint
   (name [] "Swiftlint")
 
-  (files [file-group]
+  (files [file-group _]
     (linter/select-files file-group [:swift]))
 
   (lint [{:keys [files]} conf]

--- a/src/bosslint/linter/tflint.clj
+++ b/src/bosslint/linter/tflint.clj
@@ -5,7 +5,7 @@
 (deflinter :linter/tflint
   (name [] "tflint")
 
-  (files [file-group]
+  (files [file-group _]
     (linter/select-files file-group [:terraform]))
 
   (lint [{:keys [files]} conf]

--- a/src/bosslint/linter/yamllint.clj
+++ b/src/bosslint/linter/yamllint.clj
@@ -5,7 +5,7 @@
 (deflinter :linter/yamllint
   (name [] "yamllint")
 
-  (files [file-group]
+  (files [file-group _]
     (linter/select-files file-group [:yaml]))
 
   (lint [{:keys [files]} conf]

--- a/src/bosslint/main.clj
+++ b/src/bosslint/main.clj
@@ -90,7 +90,7 @@
              println))
 
       (doseq [key linters]
-        (if-let [files (seq (linter/files key file-group))]
+        (if-let [files (seq (linter/files key file-group (get conf (keyword (name key)))))]
           (do (println (str (ansi/green (linter/name key)) ":"))
               (when linter/*verbose?*
                 (->> ["Files:"

--- a/test/bosslint/linter_test.clj
+++ b/test/bosslint/linter_test.clj
@@ -32,4 +32,21 @@
     "path/to/foo.yml"           #{:yaml}
     "path/to/foo.yaml"          #{:yaml}
     ".github/workflows/foo.yml" #{:yaml :workflow}
+
+    "playbooks/deploy.yml"           #{:yaml :ansible}
+    "playbook/deploy.yml"            #{:yaml :ansible}
+    "roles/web/tasks/main.yml"       #{:yaml :ansible}
+    "roles/web/handlers/main.yml"    #{:yaml :ansible}
+    "roles/web/meta/main.yml"        #{:yaml :ansible}
+    "roles/web/vars/main.yml"        #{:yaml :ansible}
+    "roles/web/defaults/main.yml"    #{:yaml :ansible}
+    "group_vars/all.yml"             #{:yaml :ansible}
+    "host_vars/web01.yml"            #{:yaml :ansible}
+    "inventories/prod/hosts.yml"     #{:yaml :ansible}
+    "site.yml"                       #{:yaml :ansible}
+    "playbook.yaml"                  #{:yaml :ansible}
+    "inventory.yml"                  #{:yaml :ansible}
+    "roles/web/files/index.yml"      #{:yaml}
+    "roles/web/templates/conf.yml"   #{:yaml}
+
     "path/to/foo"               #{:other}))


### PR DESCRIPTION
## Summary

- Restrict ansible-lint to YAML files that look like Ansible content (playbooks, roles, group_vars/host_vars, inventories, common top-level files) instead of running it over every YAML file.
- Add `:include-paths` and `:exclude-paths` config options on `:ansible-lint` so projects can opt extra paths in or out by regex.
- Extend the `files` multimethod to receive the linter's config map; pass it through from `main.clj`.

## Test plan

- [x] `clojure -X:test` (covers new path-type cases in `linter_test`)
- [x] Manually verify on an Ansible repo that only Ansible YAML is linted, and that `:include-paths` / `:exclude-paths` behave as documented