### PR TITLE
Update dependencies and CI actions

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -27,9 +27,9 @@ jobs:
           version: '22.3.0'
 
       - name: Setup Clojure
-        uses: DeLaGuardo/setup-clojure@13.5
+        uses: DeLaGuardo/setup-clojure@13
         with:
-          cli: '1.12.4.1602'
+          cli: '1.12.5.1654'
 
       - name: Test
         run: clojure -X:test
@@ -42,7 +42,7 @@ jobs:
         run: echo "version=$(./bosslint --version)" >> "$GITHUB_OUTPUT"
 
       - name: Upload
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: bosslint-${{ steps.get-version.outputs.version }}-${{ matrix.os }}
           path: target/bosslint*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,9 @@ jobs:
         version: '22.3.0'
 
     - name: Setup Clojure
-      uses: DeLaGuardo/setup-clojure@13.5
+      uses: DeLaGuardo/setup-clojure@13
       with:
-        cli: '1.12.4.1602'
+        cli: '1.12.5.1654'
 
     - name: Test
       run: clojure -X:test

--- a/build.clj
+++ b/build.clj
@@ -32,6 +32,7 @@
     (b/process {:command-args [native-image-bin "-jar" uber-file bin-file
                                "--diagnostics-mode"
                                "--initialize-at-build-time"
+                               "--initialize-at-run-time=org.apache.http.impl.auth.NTLMEngineImpl"
                                "--no-fallback"]})))
 
 (defn bin [_]

--- a/deps.edn
+++ b/deps.edn
@@ -1,13 +1,13 @@
 {:deps {clj-commons/clj-yaml {:mvn/version "1.0.29"}
-        clj-sub-command/clj-sub-command {:mvn/version "0.6.0"}
+        clj-sub-command/clj-sub-command {:mvn/version "1.0.0"}
         io.aviso/pretty {:mvn/version "1.4.4"}
-        org.clojure/clojure {:mvn/version "1.12.0"}
-        org.clojure/tools.cli {:mvn/version "1.1.230"}
-        org.clojure/tools.deps {:mvn/version "0.23.1512"}
-        org.slf4j/slf4j-simple {:mvn/version "2.0.17"}}
+        org.clojure/clojure {:mvn/version "1.12.5"}
+        org.clojure/tools.cli {:mvn/version "1.4.256"}
+        org.clojure/tools.deps {:mvn/version "0.31.1629"}
+        org.slf4j/slf4j-simple {:mvn/version "2.0.18"}}
 
  :aliases {:build {:extra-deps {io.github.clojure/tools.build
-                                {:git/tag "v0.10.8" :git/sha "2fdfd66"}}
+                                {:git/tag "v0.10.14" :git/sha "1176afd"}}
                    :ns-default build}
 
            :test {:extra-paths ["test"]


### PR DESCRIPTION
## Summary

- Bump Clojure deps: Clojure 1.12.5, tools.cli 1.4.256, tools.deps 0.31.1629, clj-sub-command 1.0.0, slf4j-simple 2.0.18, tools.build v0.10.14.
- Mark `org.apache.http.impl.auth.NTLMEngineImpl` for runtime initialization in `build.clj` to fix a GraalVM native-image failure introduced by the new tools.deps (its transitive Apache httpclient embeds a `SecureRandom` in a static field, which `--initialize-at-build-time` rejects).
- Bump CI actions: setup-clojure 13.6, Clojure CLI 1.12.5.1654, upload-artifact v7.

## Test plan

- [x] `clojure -X:test` passes
- [x] `clojure -T:build bin` produces a working native binary
- [x] `./target/bosslint --version` and `./target/bosslint linters` work
- [x] CI green on this branch